### PR TITLE
check buffer_pos to stay within the buffer bounds

### DIFF
--- a/src/sml_parser.c
+++ b/src/sml_parser.c
@@ -611,7 +611,7 @@ int sml_parse(struct sml_context *ctx)
 
     sml_init_elctricity(ctx);
 
-    if (ctx->sml_buf_pos>=ctx->sml_buf_len && (ctx->sml_buf_len-ctx->sml_buf_pos) <= 16 ) {
+    if (ctx->sml_buf_pos >= ctx->sml_buf_len && (ctx->sml_buf_len - ctx->sml_buf_pos) < 16 ) {
         /* buffer position has to be valid (double check because of unsigned overflow) */
         /* at least the escape sequences at beginning and end are needed in the remaining buffer */
         return SML_ERR_INCOMPLETE;

--- a/src/sml_parser.c
+++ b/src/sml_parser.c
@@ -611,8 +611,9 @@ int sml_parse(struct sml_context *ctx)
 
     sml_init_elctricity(ctx);
 
-    if (ctx->sml_buf_len < 16) {
-        /* at least the escape sequences at beginning and end are needed */
+    if (ctx->sml_buf_pos>=ctx->sml_buf_len && (ctx->sml_buf_len-ctx->sml_buf_pos) <= 16 ) {
+        /* buffer position has to be valid (double check because of unsigned overflow) */
+        /* at least the escape sequences at beginning and end are needed in the remaining buffer */
         return SML_ERR_INCOMPLETE;
     }
 


### PR DESCRIPTION
Index out of bounds error in libsml-testing/EMH-ED300L_delivery.bin
Reason: iteration of the buffer position without checking the bounds